### PR TITLE
Timestamp log file lines

### DIFF
--- a/python/lsst/ci/build.py
+++ b/python/lsst/ci/build.py
@@ -9,6 +9,7 @@ import pipes
 import time
 import eups.tags
 import contextlib
+import datetime
 
 from .prepare import Manifest
 
@@ -189,6 +190,7 @@ class Builder(object):
             # execute the build file from the product directory, capturing the output and return code
             process = subprocess.Popen(buildscript, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=productdir)
             for line in iter(process.stdout.readline, ''):
+                line = "[%sZ] %s" % (datetime.datetime.utcnow().isoformat(), line)
                 logfp.write(line)
                 progress.reportProgress()
 

--- a/python/lsst/ci/build.py
+++ b/python/lsst/ci/build.py
@@ -149,6 +149,7 @@ class Builder(object):
             %(setups)s
             EOF
             set +x
+            echo "Setting up environment with EUPS"
             setup --vro=_build.tags -r .
             set -x
 

--- a/python/lsst/ci/build.py
+++ b/python/lsst/ci/build.py
@@ -114,6 +114,7 @@ class Builder(object):
         buildscript = os.path.join(productdir, '_build.sh')
         logfile = os.path.join(productdir, '_build.log')
         eupsdir = eups.productDir("eups")
+        eupspath = os.environ["EUPS_PATH"]
 
         # construct the tags file with exact dependencies
         setups = [ 
@@ -133,8 +134,9 @@ class Builder(object):
             # stop on any error
             set -ex
 
-            # define the setup command
-            . %(eupsdir)s/bin/setups.sh 
+            # define the setup command, but preserve EUPS_PATH
+            . %(eupsdir)s/bin/setups.sh
+            export EUPS_PATH="%(eupspath)s"
 
             cd %(productdir)s
 
@@ -176,6 +178,7 @@ class Builder(object):
                     'productdir' : productdir,
                     'setups': '\n            '.join(setups),
                     'eupsdir': eupsdir,
+                    'eupspath': eupspath,
                 }
             )
 


### PR DESCRIPTION
Make log files more informative when debugging performance issues.

NOTE: I'm not sure if buildbot's scripts parse the log files in some way (I don't think they do) -- if they do, this change may break them.
