### PR TITLE
clean repo of *all* untracked files (including _build*) during prepare

### DIFF
--- a/python/lsst/ci/prepare.py
+++ b/python/lsst/ci/prepare.py
@@ -246,7 +246,7 @@ class ProductFetcher(object):
 
         # clean up the working directory (eg., remove remnants of
         # previous builds)
-        git.clean("-d", "-f", "-q")
+        git.clean("-d", "-f", "-q", "-x")
 
         print >>sys.stderr, " ok (%.1f sec)." % (time.time() - t0)
         return ref, sha1


### PR DESCRIPTION
This is to prevent _build.\* files left over from previous runs, which may be in
product build dirs that were not reached during the current build due to an
error condition, from being pickedup and archived or displayed.
