### PR TITLE
(bugfix) copy default refs list in ProductFetcher::_ref_candidates()

### DIFF
--- a/python/lsst/ci/prepare.py
+++ b/python/lsst/ci/prepare.py
@@ -13,6 +13,7 @@ import subprocess
 import collections
 import abc
 import yaml
+import copy
 
 import tsort
 
@@ -175,7 +176,7 @@ class ProductFetcher(object):
 
         # ref precedence should be:
         # user specified refs > repos.yaml default ref > implicit master
-        refs = self.refs
+        refs = copy.copy(self.refs)
         origin, ref = self._repos_yaml_coordinates(product)
 
         if ref:


### PR DESCRIPTION
... instead of aliasing the global/default value. Prior to this fix,
when multiple products were being prepared, the ref list for product
currently being prepared also became the global/default ref list for
each successive product.  This behavior was not visible when operating
on a single product or using only the CLI supplied ref list.
