### PR TITLE
(DM-4113) set `lfs.batch=false` when cloning lfs repos

### DIFF
--- a/python/lsst/ci/prepare.py
+++ b/python/lsst/ci/prepare.py
@@ -283,6 +283,7 @@ class ProductFetcher(object):
                     # lfs will pickup the .gitconfig and pull lfs objects for
                     # the default ref during clone.  Config options set on the
                     # cli during the clone get recorded in `.git/config'
+                    args += ['-c', 'lfs.batch=false']
                     args += ['-c', 'filter.lfs.required']
                     args += ['-c', 'filter.lfs.smudge=git-lfs smudge %f']
                     args += ['-c', 'filter.lfs.clean=git-lfs clean %f']


### PR DESCRIPTION
lfs > 1.0.0 appears to ignore batch=false from a commited .gitconfig
file.
