### PR TITLE
Check that the yaml variable is not None

### DIFF
--- a/python/lsst/ci/prepare.py
+++ b/python/lsst/ci/prepare.py
@@ -179,7 +179,7 @@ class ProductFetcher(object):
         refs = copy.copy(self.refs)
         yaml = self._repos_yaml_lookup(product)
 
-        if yaml.ref:
+        if yaml is not None and yaml.ref:
             refs.append(yaml.ref)
 
         # Add 'master' to list of refs, if not there already


### PR DESCRIPTION
This fixes an `AttributeError: 'NoneType' object has no attribute 'ref'`
when a YAML file is not provided with the --repos option
