### PR TITLE
detect and cleanup zero size git index files

### DIFF
--- a/python/lsst/ci/prepare.py
+++ b/python/lsst/ci/prepare.py
@@ -329,6 +329,14 @@ class ProductFetcher(object):
 
         # update from origin
         if not self.no_fetch:
+            # git is unable to recover from a corrupted/zero size index file
+            # without manual deletion of the index file
+            # https://jira.lsstcorp.org/browse/DM-13494
+            index = os.path.join(git.cwd, '.git', 'index')
+            if os.path.getsize(index) == 0:
+                os.remove(index)
+                git.reset('--hard')
+
             # the line below should be equivalent to:
             #     git.fetch("origin", "--force", "--prune")
             #     git.fetch("origin", "--force", "--tags")


### PR DESCRIPTION
An existing, corrupt/zero size git index seems to break virtually all
operations in an existing clone and require manual cleanup.