### PR TITLE
DM-32648: Set default branch from remote.

### DIFF
--- a/python/lsst/ci/git.py
+++ b/python/lsst/ci/git.py
@@ -107,6 +107,9 @@ class Git:
     async def lfs(self, *args, **kwargs):
         return await self('lfs', *args, **kwargs)
 
+    async def remote(self, *args, **kwargs):
+        return await self('remote', *args, **kwargs)
+
     def sync_checkout(self, *args, **kwargs):
         return self._sync('checkout', *args, **kwargs)
 
@@ -139,3 +142,6 @@ class Git:
 
     def sync_lfs(self, *args, **kwargs):
         return self._sync('lfs', *args, **kwargs)
+
+    def sync_remote(self, *args, **kwargs):
+        return self._sync('remote', *args, **kwargs)

--- a/python/lsst/ci/prepare.py
+++ b/python/lsst/ci/prepare.py
@@ -358,6 +358,10 @@ class ProductFetcher:
                             "+refs/heads/*:refs/remotes/origin/*",
                             "refs/tags/*:refs/tags/*")
 
+            # ensure default branch matches origin
+            # (mostly for eups pkgautoversion)
+            await git.remote("set-head", "origin", "-a")
+
         # find a ref that matches, checkout it
         for ref in self.ref_candidates(repo_spec, refs):
             sha1, _ = await git.rev_parse("-q", "--verify", "refs/remotes/origin/" + ref, return_status=True)


### PR DESCRIPTION
eups pkgautoversion relies on the local understanding of the default branch to compute version strings.  Set it in case it has changed.