### PR TITLE
DM-41151: Fix handling of multiple products in rebuild script.

### DIFF
--- a/bin/lsst-build
+++ b/bin/lsst-build
@@ -57,5 +57,6 @@ build.add_argument(
 )
 
 args = parser.parse_args()
+args.products = args.products[0].split()
 
 args.func(args)


### PR DESCRIPTION
This small patch fixes the Builder class interpreting the $PRODUCTS argument as a single string.