### PR TITLE
DM-49990: Allow eups distrib to install existing packages

### DIFF
--- a/bin/lsst-build
+++ b/bin/lsst-build
@@ -55,6 +55,8 @@ build.set_defaults(func=Builder.run)
 build.add_argument(
     "build_dir", type=str, help="Build directory with manifest.txt built by the `prepare` subcommand"
 )
+build.add_argument(
+        "--no-binary-fetch", help="Will not attempt to download binaries, instead it will build products from source", action="store_true")
 
 args = parser.parse_args()
 

--- a/python/lsst/ci/build.py
+++ b/python/lsst/ci/build.py
@@ -16,8 +16,8 @@ from typing import TextIO
 
 import eups
 import eups.tags
-import yaml
 import requests
+import yaml
 
 from . import models
 from .prepare import Manifest
@@ -153,7 +153,7 @@ class Builder:
     eups
         an eups object for eups operations (e.g. discovering product info)
     no_binary_fetch
-        If true, builder will not fetch binaries from server if they are available
+        builder will not fetch binaries from server if they are available
     """
 
     def __init__(
@@ -296,14 +296,7 @@ class Builder:
         productdir = os.path.abspath(os.path.join(self.build_dir, product.name))
         buildscript = os.path.join(productdir, "_build.sh")
         logfile = os.path.join(productdir, "_build.log")
-        eupsdir = eups.productDir("eups")
         eupspath = os.environ["EUPS_PATH"]
-
-        # construct the tags file with exact dependencies
-        setups = [
-            f"\t{dep.name:20s} {dep.version}"
-            for dep in self.manifest.product_index.flat_dependencies(product)
-        ]
 
         # create the buildscript
         with open(buildscript, "w", encoding="utf-8") as fp:

--- a/python/lsst/ci/build.py
+++ b/python/lsst/ci/build.py
@@ -308,21 +308,12 @@ class Builder:
             set -ex
 
             # define the setup command, but preserve EUPS_PATH
-            #. "{eupsdir}/bin/setups.sh"
-            #export EUPS_PATH="{eupspath}"
-
-            cd "{productdir}"
-
-            # clean up the working directory
-            git reset --hard
-            git clean -d -f -q -x -e '_build.*'
+            export EUPS_PATH="{eupspath}"
 
             # fetch
             export EUPS_PKGROOT={server_path}
-            eups distrib install {product.name} {product.version}
+            eups distrib install -j {product.name} {product.version}
 
-            # explicitly append SHA1 to pkginfo
-            # echo SHA1={product.sha1} >> $(eups list {product.name} {product.version} -d)/ups/pkginfo
             """
             )
 
@@ -364,7 +355,7 @@ class Builder:
         return (eups_prod, retcode, logfile)
 
     def _check_if_in_distrib(self, product, server_path):
-        res = requests.get(f"{server_path}/{product.name}-{product.version}@Linux64.tar.gz")
+        res = requests.get(f"{server_path}/{product.name}-{product.version}@{self.eups.flavor}.tar.gz")
         return res.status_code == 200
 
     def _build_product_if_needed(self, product):


### PR DESCRIPTION
This will pull tarballs from eups.lsst.codes and install them instead of building every package. This should speed up stack-os-matrix as well as local builds. 