### PR TITLE
Report an error when binary install fails

### DIFF
--- a/python/lsst/ci/build.py
+++ b/python/lsst/ci/build.py
@@ -109,7 +109,10 @@ class ProgressReporter:
                 self.out.write("(already installed).\n")
                 self.out.flush()
             elif fetched:
-                print(f"(installed from binary in {elapsed_time:.1f} sec).")
+                if not retcode:
+                    print(f"(installed from binary in {elapsed_time:.1f} sec).")
+                else:
+                    print(f"(failed to install from binary, exit code = {retcode}).")
                 self.out.flush()
             else:
                 if retcode:


### PR DESCRIPTION
I was getting an error from eups.lsst.codes but there was no error being reported at all. This change at least reports that there was a problem...